### PR TITLE
build.sh: fix bash-isms

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,15 +1,13 @@
 #!/bin/sh
 
 family=SourceCodePro
-weights=('Black' 'Bold' 'ExtraLight' 'Light' 'Medium' 'Regular' 'Semibold')
+weights='Black Bold ExtraLight Light Medium Regular Semibold'
 
 # clean existing build artifacts
 rm -rf target/
-mkdir target/
-mkdir target/OTF/
-mkdir target/TTF/
+mkdir target/ target/OTF/ target/TTF/
 
-for w in ${weights[@]};
+for w in $weights
 do
   makeotf -f Roman/$w/font.pfa -r -o target/OTF/$family-$w.otf
   makeotf -f Roman/$w/font.ttf -gf GlyphOrderAndAliasDB_TT -r -o target/TTF/$family-$w.ttf


### PR DESCRIPTION
Fixes usage of non-POSIX shell features in `build.sh`.
