### PR TITLE
Fix download links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ by using the AFDKO makeotf tool.
 
 ## Download the fonts (OTF, TTF, WOFF, WOFF2, EOT)
 
-* [Latest release](../../releases/latest)
-* [All releases](../../releases)
+* [Latest release](releases/latest)
+* [All releases](releases)
 
 ## Font installation instructions
 


### PR DESCRIPTION
So you get linked to the right location from https://github.com/adobe-fonts/source-code-pro/blob/master/README.md and https://github.com/adobe-fonts/source-code-pro