### PR TITLE
Change fontWeights variable in build.sh zsh compatible

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env sh
 
 family=SourceCodePro
-romanWeights='Black Bold ExtraLight Light Medium Regular Semibold'
-italicWeights='BlackIt BoldIt ExtraLightIt LightIt MediumIt It SemiboldIt'
+romanWeights=('Black' 'Bold' 'ExtraLight' 'Light' 'Medium' 'Regular' 'Semibold')
+italicWeights=('BlackIt' 'BoldIt' 'ExtraLightIt' 'LightIt' 'MediumIt' 'It' 'SemiboldIt')
 
 # path to Python script that adds the SVG table
 addSVG=$(cd $(dirname "$0") && pwd -P)/addSVGtable.py


### PR DESCRIPTION
In `zsh`, shell script can not iterate string with whitespaces.

like this
```
makeotf [Error] Could not find the input font file at 'Roman/Instances/Black Bold ExtraLight Light Medium Regular Semibold/font.ufo'.

makeotf [Error] Could not find the input font file at 'Roman/Instances/Black Bold ExtraLight Light Medium Regular Semibold/font.ttf'.
makeotf [Error] Could not find the features file at 'Roman/Instances/Black Bold ExtraLight Light Medium Regular Semibold/font.ufo/features.fea'.
ERROR: The path to the font is invalid.
ERROR: The path to the font is invalid.
```

so I fixed this with array of strings.

it works in bash too