### PR TITLE
invoke addSVGtable using the python decided by AFDKO

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env sh
 
 family=SourceCodePro
-romanWeights=('Black' 'Bold' 'ExtraLight' 'Light' 'Medium' 'Regular' 'Semibold')
-italicWeights=('BlackIt' 'BoldIt' 'ExtraLightIt' 'LightIt' 'MediumIt' 'It' 'SemiboldIt')
+romanWeights='Black Bold ExtraLight Light Medium Regular Semibold'
+italicWeights='BlackIt BoldIt ExtraLightIt LightIt MediumIt It SemiboldIt'
 
 # path to Python script that adds the SVG table
+cmdDirPath="$(dirname `which makeotf`)"
+. "${cmdDirPath}/setFDKPaths"
 addSVG=$(cd $(dirname "$0") && pwd -P)/addSVGtable.py
 
 # path to UVS file
@@ -21,8 +23,8 @@ do
   font_path=Roman/Instances/$w/font
   makeotf -f $font_path.ufo -r -ci "$UVS" -o $otfDir/$family-$w.otf
   makeotf -f $font_path.ttf -r -ci "$UVS" -o $ttfDir/$family-$w.ttf -ff $font_path.ufo/features.fea
-  "$addSVG" $otfDir/$family-$w.otf svg
-  "$addSVG" $ttfDir/$family-$w.ttf svg
+  "$AFDKO_Python" "$addSVG" $otfDir/$family-$w.otf svg
+  "$AFDKO_Python" "$addSVG" $ttfDir/$family-$w.ttf svg
 done
 
 for w in $italicWeights
@@ -30,6 +32,6 @@ do
   font_path=Italic/Instances/$w/font
   makeotf -f $font_path.ufo -r -ci "$UVS" -o $otfDir/$family-$w.otf
   makeotf -f $font_path.ttf -r -ci "$UVS" -o $ttfDir/$family-$w.ttf -ff $font_path.ufo/features.fea
-  "$addSVG" $otfDir/$family-$w.otf svg
-  "$addSVG" $ttfDir/$family-$w.ttf svg
+  "$AFDKO_Python" "$addSVG" $otfDir/$family-$w.otf svg
+  "$AFDKO_Python" "$addSVG" $ttfDir/$family-$w.ttf svg
 done


### PR DESCRIPTION
Use the python determined by `setFDKPaths` rather than depending on the shebang. AFDKO ships with an embedded python with all necessary dependencies.  The user of AFDKO should use that python distribution, as in #164.

Also undo commit [c9a8cd11a6](https://github.com/adobe-fonts/source-code-pro/commit/c9a8cd11a69366f44edd652c128e47e3fae030f4), which make the script incompatible with what the shebang specifies (see [comment](https://github.com/adobe-fonts/source-code-pro/commit/c9a8cd11a69366f44edd652c128e47e3fae030f4#commitcomment-24940003)).