### PR TITLE
Update brew instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ by using the AFDKO makeotf tool.
 * [Windows](https://www.microsoft.com/en-us/Typography/TrueTypeInstall.aspx)
 * [Linux/Unix-based systems](https://github.com/adobe-fonts/source-code-pro/issues/17#issuecomment-8967116)
 * Homebrew (macOS)<br/>
-	`brew cask install font-source-code-pro`
+	`brew tap caskroom/fonts && brew cask install font-source-code-pro`
 * Bower<br/>
 	`bower install git://github.com/adobe-fonts/source-code-pro.git#release`
 * npm 2.x<br/>


### PR DESCRIPTION
Users who haven't tapped caskroom/fonts first won't be able to install the font.

Trying to install font-source-code-pro won't generate an obvious error message either, potentially leaving users to assume no such formula exists anymore