### PR TITLE
Added ./ to source-code-pro.css fixing Next 9 building issue

### DIFF
--- a/source-code-pro.css
+++ b/source-code-pro.css
@@ -3,11 +3,11 @@
     font-weight: 200;
     font-style: normal;
     font-stretch: normal;
-    src: url('EOT/SourceCodePro-ExtraLight.eot') format('embedded-opentype'),
-         url('WOFF2/TTF/SourceCodePro-ExtraLight.ttf.woff2') format('woff2'),
-         url('WOFF/OTF/SourceCodePro-ExtraLight.otf.woff') format('woff'),
-         url('OTF/SourceCodePro-ExtraLight.otf') format('opentype'),
-         url('TTF/SourceCodePro-ExtraLight.ttf') format('truetype');
+    src: url('./EOT/SourceCodePro-ExtraLight.eot') format('embedded-opentype'),
+         url('./WOFF2/TTF/SourceCodePro-ExtraLight.ttf.woff2') format('woff2'),
+         url('./WOFF/OTF/SourceCodePro-ExtraLight.otf.woff') format('woff'),
+         url('./OTF/SourceCodePro-ExtraLight.otf') format('opentype'),
+         url('./TTF/SourceCodePro-ExtraLight.ttf') format('truetype');
 }
 
 @font-face{
@@ -15,11 +15,11 @@
     font-weight: 200;
     font-style: italic;
     font-stretch: normal;
-    src: url('EOT/SourceCodePro-ExtraLightIt.eot') format('embedded-opentype'),
-         url('WOFF2/TTF/SourceCodePro-ExtraLightIt.ttf.woff2') format('woff2'),
-         url('WOFF/OTF/SourceCodePro-ExtraLightIt.otf.woff') format('woff'),
-         url('OTF/SourceCodePro-ExtraLightIt.otf') format('opentype'),
-         url('TTF/SourceCodePro-ExtraLightIt.ttf') format('truetype');
+    src: url('./EOT/SourceCodePro-ExtraLightIt.eot') format('embedded-opentype'),
+         url('./WOFF2/TTF/SourceCodePro-ExtraLightIt.ttf.woff2') format('woff2'),
+         url('./WOFF/OTF/SourceCodePro-ExtraLightIt.otf.woff') format('woff'),
+         url('./OTF/SourceCodePro-ExtraLightIt.otf') format('opentype'),
+         url('./TTF/SourceCodePro-ExtraLightIt.ttf') format('truetype');
 }
 
 @font-face{
@@ -27,11 +27,11 @@
     font-weight: 300;
     font-style: normal;
     font-stretch: normal;
-    src: url('EOT/SourceCodePro-Light.eot') format('embedded-opentype'),
-         url('WOFF2/TTF/SourceCodePro-Light.ttf.woff2') format('woff2'),
-         url('WOFF/OTF/SourceCodePro-Light.otf.woff') format('woff'),
-         url('OTF/SourceCodePro-Light.otf') format('opentype'),
-         url('TTF/SourceCodePro-Light.ttf') format('truetype');
+    src: url('./EOT/SourceCodePro-Light.eot') format('embedded-opentype'),
+         url('./WOFF2/TTF/SourceCodePro-Light.ttf.woff2') format('woff2'),
+         url('./WOFF/OTF/SourceCodePro-Light.otf.woff') format('woff'),
+         url('./OTF/SourceCodePro-Light.otf') format('opentype'),
+         url('./TTF/SourceCodePro-Light.ttf') format('truetype');
 }
 
 @font-face{
@@ -39,11 +39,11 @@
     font-weight: 300;
     font-style: italic;
     font-stretch: normal;
-    src: url('EOT/SourceCodePro-LightIt.eot') format('embedded-opentype'),
-         url('WOFF2/TTF/SourceCodePro-LightIt.ttf.woff2') format('woff2'),
-         url('WOFF/OTF/SourceCodePro-LightIt.otf.woff') format('woff'),
-         url('OTF/SourceCodePro-LightIt.otf') format('opentype'),
-         url('TTF/SourceCodePro-LightIt.ttf') format('truetype');
+    src: url('./EOT/SourceCodePro-LightIt.eot') format('embedded-opentype'),
+         url('./WOFF2/TTF/SourceCodePro-LightIt.ttf.woff2') format('woff2'),
+         url('./WOFF/OTF/SourceCodePro-LightIt.otf.woff') format('woff'),
+         url('./OTF/SourceCodePro-LightIt.otf') format('opentype'),
+         url('./TTF/SourceCodePro-LightIt.ttf') format('truetype');
 }
 
 @font-face{
@@ -51,11 +51,11 @@
     font-weight: 400;
     font-style: normal;
     font-stretch: normal;
-    src: url('EOT/SourceCodePro-Regular.eot') format('embedded-opentype'),
-         url('WOFF2/TTF/SourceCodePro-Regular.ttf.woff2') format('woff2'),
-         url('WOFF/OTF/SourceCodePro-Regular.otf.woff') format('woff'),
-         url('OTF/SourceCodePro-Regular.otf') format('opentype'),
-         url('TTF/SourceCodePro-Regular.ttf') format('truetype');
+    src: url('./EOT/SourceCodePro-Regular.eot') format('embedded-opentype'),
+         url('./WOFF2/TTF/SourceCodePro-Regular.ttf.woff2') format('woff2'),
+         url('./WOFF/OTF/SourceCodePro-Regular.otf.woff') format('woff'),
+         url('./OTF/SourceCodePro-Regular.otf') format('opentype'),
+         url('./TTF/SourceCodePro-Regular.ttf') format('truetype');
 }
 
 @font-face{
@@ -63,11 +63,11 @@
     font-weight: 400;
     font-style: italic;
     font-stretch: normal;
-    src: url('EOT/SourceCodePro-It.eot') format('embedded-opentype'),
-         url('WOFF2/TTF/SourceCodePro-It.ttf.woff2') format('woff2'),
-         url('WOFF/OTF/SourceCodePro-It.otf.woff') format('woff'),
-         url('OTF/SourceCodePro-It.otf') format('opentype'),
-         url('TTF/SourceCodePro-It.ttf') format('truetype');
+    src: url('./EOT/SourceCodePro-It.eot') format('embedded-opentype'),
+         url('./WOFF2/TTF/SourceCodePro-It.ttf.woff2') format('woff2'),
+         url('./WOFF/OTF/SourceCodePro-It.otf.woff') format('woff'),
+         url('./OTF/SourceCodePro-It.otf') format('opentype'),
+         url('./TTF/SourceCodePro-It.ttf') format('truetype');
 }
 
 @font-face{
@@ -75,11 +75,11 @@
     font-weight: 500;
     font-style: normal;
     font-stretch: normal;
-    src: url('EOT/SourceCodePro-Medium.eot') format('embedded-opentype'),
-         url('WOFF2/TTF/SourceCodePro-Medium.ttf.woff2') format('woff2'),
-         url('WOFF/OTF/SourceCodePro-Medium.otf.woff') format('woff'),
-         url('OTF/SourceCodePro-Medium.otf') format('opentype'),
-         url('TTF/SourceCodePro-Medium.ttf') format('truetype');
+    src: url('./EOT/SourceCodePro-Medium.eot') format('embedded-opentype'),
+         url('./WOFF2/TTF/SourceCodePro-Medium.ttf.woff2') format('woff2'),
+         url('./WOFF/OTF/SourceCodePro-Medium.otf.woff') format('woff'),
+         url('./OTF/SourceCodePro-Medium.otf') format('opentype'),
+         url('./TTF/SourceCodePro-Medium.ttf') format('truetype');
 }
 
 @font-face{
@@ -87,11 +87,11 @@
     font-weight: 500;
     font-style: italic;
     font-stretch: normal;
-    src: url('EOT/SourceCodePro-MediumIt.eot') format('embedded-opentype'),
-         url('WOFF2/TTF/SourceCodePro-MediumIt.ttf.woff2') format('woff2'),
-         url('WOFF/OTF/SourceCodePro-MediumIt.otf.woff') format('woff'),
-         url('OTF/SourceCodePro-MediumIt.otf') format('opentype'),
-         url('TTF/SourceCodePro-MediumIt.ttf') format('truetype');
+    src: url('./EOT/SourceCodePro-MediumIt.eot') format('embedded-opentype'),
+         url('./WOFF2/TTF/SourceCodePro-MediumIt.ttf.woff2') format('woff2'),
+         url('./WOFF/OTF/SourceCodePro-MediumIt.otf.woff') format('woff'),
+         url('./OTF/SourceCodePro-MediumIt.otf') format('opentype'),
+         url('./TTF/SourceCodePro-MediumIt.ttf') format('truetype');
 }
 
 @font-face{
@@ -99,11 +99,11 @@
     font-weight: 600;
     font-style: normal;
     font-stretch: normal;
-    src: url('EOT/SourceCodePro-Semibold.eot') format('embedded-opentype'),
-         url('WOFF2/TTF/SourceCodePro-Semibold.ttf.woff2') format('woff2'),
-         url('WOFF/OTF/SourceCodePro-Semibold.otf.woff') format('woff'),
-         url('OTF/SourceCodePro-Semibold.otf') format('opentype'),
-         url('TTF/SourceCodePro-Semibold.ttf') format('truetype');
+    src: url('./EOT/SourceCodePro-Semibold.eot') format('embedded-opentype'),
+         url('./WOFF2/TTF/SourceCodePro-Semibold.ttf.woff2') format('woff2'),
+         url('./WOFF/OTF/SourceCodePro-Semibold.otf.woff') format('woff'),
+         url('./OTF/SourceCodePro-Semibold.otf') format('opentype'),
+         url('./TTF/SourceCodePro-Semibold.ttf') format('truetype');
 }
 
 @font-face{
@@ -111,11 +111,11 @@
     font-weight: 600;
     font-style: italic;
     font-stretch: normal;
-    src: url('EOT/SourceCodePro-SemiboldIt.eot') format('embedded-opentype'),
-         url('WOFF2/TTF/SourceCodePro-SemiboldIt.ttf.woff2') format('woff2'),
-         url('WOFF/OTF/SourceCodePro-SemiboldIt.otf.woff') format('woff'),
-         url('OTF/SourceCodePro-SemiboldIt.otf') format('opentype'),
-         url('TTF/SourceCodePro-SemiboldIt.ttf') format('truetype');
+    src: url('./EOT/SourceCodePro-SemiboldIt.eot') format('embedded-opentype'),
+         url('./WOFF2/TTF/SourceCodePro-SemiboldIt.ttf.woff2') format('woff2'),
+         url('./WOFF/OTF/SourceCodePro-SemiboldIt.otf.woff') format('woff'),
+         url('./OTF/SourceCodePro-SemiboldIt.otf') format('opentype'),
+         url('./TTF/SourceCodePro-SemiboldIt.ttf') format('truetype');
 }
 
 @font-face{
@@ -123,11 +123,11 @@
     font-weight: 700;
     font-style: normal;
     font-stretch: normal;
-    src: url('EOT/SourceCodePro-Bold.eot') format('embedded-opentype'),
-         url('WOFF2/TTF/SourceCodePro-Bold.ttf.woff2') format('woff2'),
-         url('WOFF/OTF/SourceCodePro-Bold.otf.woff') format('woff'),
-         url('OTF/SourceCodePro-Bold.otf') format('opentype'),
-         url('TTF/SourceCodePro-Bold.ttf') format('truetype');
+    src: url('./EOT/SourceCodePro-Bold.eot') format('embedded-opentype'),
+         url('./WOFF2/TTF/SourceCodePro-Bold.ttf.woff2') format('woff2'),
+         url('./WOFF/OTF/SourceCodePro-Bold.otf.woff') format('woff'),
+         url('./OTF/SourceCodePro-Bold.otf') format('opentype'),
+         url('./TTF/SourceCodePro-Bold.ttf') format('truetype');
 }
 
 @font-face{
@@ -135,11 +135,11 @@
     font-weight: 700;
     font-style: italic;
     font-stretch: normal;
-    src: url('EOT/SourceCodePro-BoldIt.eot') format('embedded-opentype'),
-         url('WOFF2/TTF/SourceCodePro-BoldIt.ttf.woff2') format('woff2'),
-         url('WOFF/OTF/SourceCodePro-BoldIt.otf.woff') format('woff'),
-         url('OTF/SourceCodePro-BoldIt.otf') format('opentype'),
-         url('TTF/SourceCodePro-BoldIt.ttf') format('truetype');
+    src: url('./EOT/SourceCodePro-BoldIt.eot') format('embedded-opentype'),
+         url('./WOFF2/TTF/SourceCodePro-BoldIt.ttf.woff2') format('woff2'),
+         url('./WOFF/OTF/SourceCodePro-BoldIt.otf.woff') format('woff'),
+         url('./OTF/SourceCodePro-BoldIt.otf') format('opentype'),
+         url('./TTF/SourceCodePro-BoldIt.ttf') format('truetype');
 }
 
 @font-face{
@@ -147,11 +147,11 @@
     font-weight: 900;
     font-style: normal;
     font-stretch: normal;
-    src: url('EOT/SourceCodePro-Black.eot') format('embedded-opentype'),
-         url('WOFF2/TTF/SourceCodePro-Black.ttf.woff2') format('woff2'),
-         url('WOFF/OTF/SourceCodePro-Black.otf.woff') format('woff'),
-         url('OTF/SourceCodePro-Black.otf') format('opentype'),
-         url('TTF/SourceCodePro-Black.ttf') format('truetype');
+    src: url('./EOT/SourceCodePro-Black.eot') format('embedded-opentype'),
+         url('./WOFF2/TTF/SourceCodePro-Black.ttf.woff2') format('woff2'),
+         url('./WOFF/OTF/SourceCodePro-Black.otf.woff') format('woff'),
+         url('./OTF/SourceCodePro-Black.otf') format('opentype'),
+         url('./TTF/SourceCodePro-Black.ttf') format('truetype');
 }
 
 @font-face{
@@ -159,9 +159,9 @@
     font-weight: 900;
     font-style: italic;
     font-stretch: normal;
-    src: url('EOT/SourceCodePro-BlackIt.eot') format('embedded-opentype'),
-         url('WOFF2/TTF/SourceCodePro-BlackIt.ttf.woff2') format('woff2'),
-         url('WOFF/OTF/SourceCodePro-BlackIt.otf.woff') format('woff'),
-         url('OTF/SourceCodePro-BlackIt.otf') format('opentype'),
-         url('TTF/SourceCodePro-BlackIt.ttf') format('truetype');
+    src: url('./EOT/SourceCodePro-BlackIt.eot') format('embedded-opentype'),
+         url('./WOFF2/TTF/SourceCodePro-BlackIt.ttf.woff2') format('woff2'),
+         url('./WOFF/OTF/SourceCodePro-BlackIt.otf.woff') format('woff'),
+         url('./OTF/SourceCodePro-BlackIt.otf') format('opentype'),
+         url('./TTF/SourceCodePro-BlackIt.ttf') format('truetype');
 }


### PR DESCRIPTION
When importing this package into a Next 9 project, the compiler is having a hard time in the build:
`ModuleNotFoundError: Module not found: Error: Can't resolve 'EOT/SourceCodePro-Black.eot' in '<PROJECT_PATH>/node_modules/source-code-pro'`

Using relative paths fixed the issue.
