### PR TITLE
made font buildable on Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,13 @@ in user interface (UI) environments.
 
 ### Requirements
 
-To build the binary font files from source, you need to have installed the
-[Adobe Font Development Kit for OpenType](https://github.com/adobe-type-tools/afdko/) (AFDKO).
+To build the binary font files from source, you need Python 3 along with the
+[Adobe Font Development Kit for OpenType](https://github.com/adobe-type-tools/afdko/) (AFDKO) and
+[FontTools](https://github.com/fonttools/fonttools) packages, which you can install with
+
+```sh
+pip3 install afdko fonttools
+```
 
 ### Building one font
 
@@ -29,30 +34,30 @@ are generated with the `otf2ttf` and `ttfcomponentizer` tools.
 Commands to build the Regular style OTF font:
 
 ```sh
-$ cd Roman/Instances/Regular/
-$ makeotf -r -gs -omitMacNames
+cd Roman/Instances/Regular/
+makeotf -r -gs -omitMacNames
 ```
 
 Commands to generate the Regular style TTF font:
 
 ```sh
-$ otf2ttf SourceCodePro-Regular.otf
-$ ttfcomponentizer SourceCodePro-Regular.ttf
+otf2ttf SourceCodePro-Regular.otf
+ttfcomponentizer SourceCodePro-Regular.ttf
 ```
 
 ### Building all non-variable fonts
 
 For convenience, a shell script named **build.sh** is provided in the root directory.
-It builds all OTFs and TTFs, and can be executed by typing:
+It builds all OTFs and TTFs into a directory called **target/**. It can be executed by typing:
 
 ```sh
-$ ./build.sh
+./build.sh
 ```
 
 or this on Windows:
 
 ```sh
-> build.cmd
+build.cmd
 ```
 
 ### Building the variable fonts
@@ -60,12 +65,12 @@ or this on Windows:
 To build the variable TTFs you must install **fontmake** using this command:
 
 ```sh
-$ pip install fontmake
+pip3 install fontmake
 ```
 
 A shell script named **buildVFs.sh** is provided in the root directory.
 It generates four variable fonts (two CFF2-OTFs and two TTFs), and can be executed by typing:
 
 ```sh
-$ ./buildVFs.sh
+./buildVFs.sh
 ```

--- a/addSVGtable.py
+++ b/addSVGtable.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-from __future__ import print_function
+#!/usr/bin/env python3
 
 """
 Adds an SVG table to a TTF or OTF font.
@@ -26,10 +25,8 @@ reWhiteSpace = re.compile(r">\s+<", re.DOTALL)
 
 
 def readFile(filePath):
-    f = open(filePath, "rt")
-    data = f.read()
-    f.close()
-    return data
+    with open(filePath, "rt") as f:
+        return f.read()
 
 
 def setIDvalue(data, gid):
@@ -143,10 +140,9 @@ def validateSVGfiles(svgFilePathsList):
 
 def getFontFormat(fontFilePath):
     # these lines were scavenged from fontTools
-    f = open(fontFilePath, "rb")
-    header = f.read(256)
-    head = header[:4]
-    f.close()
+    with open(fontFilePath, "rb") as f:
+        header = f.read(256)
+        head = header[:4]
     if head == b"OTTO":
         return "OTF"
     elif head in (b"\0\1\0\0", b"true"):

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -e
 

--- a/buildVFs.sh
+++ b/buildVFs.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
Tried building it on Ubuntu, first I got a `./build.sh: 6: ./build.sh: Syntax error: "(" unexpected` error, which is because `sh` is not `bash` on Ubuntu/Debian (looks like someone already pointed out that adding those brackets was a breaking change https://github.com/adobe-fonts/source-code-pro/commit/c9a8cd11a69366f44edd652c128e47e3fae030f4#commitcomment-24940003). Then I got a  I got the `fontTools` import error, because I installed FontTools with `pip3` and the shebang in addSVGTable.py was making the script run as Python 2, which didn't have FontTools installed. 