### PR TITLE
Correct `format()` in `source-code-variable.css`

### DIFF
--- a/source-code-variable.css
+++ b/source-code-variable.css
@@ -3,9 +3,9 @@
     font-weight: 200 900;
     font-style: normal;
     font-stretch: normal;
-    src: url('./WOFF2/VAR/SourceCodeVariable-Roman.ttf.woff2') format('woff2'),
-         url('./WOFF/VAR/SourceCodeVariable-Roman.ttf.woff') format('woff'),
-         url('./VAR/SourceCodeVariable-Roman.ttf') format('truetype');
+    src: url('./WOFF2/VAR/SourceCodeVariable-Roman.ttf.woff2') format('woff2-variations'),
+         url('./WOFF/VAR/SourceCodeVariable-Roman.ttf.woff') format('woff-variations'),
+         url('./VAR/SourceCodeVariable-Roman.ttf') format('truetype-variations');
 }
 
 @font-face{
@@ -13,7 +13,7 @@
     font-weight: 200 900;
     font-style: italic;
     font-stretch: normal;
-    src: url('./WOFF2/VAR/SourceCodeVariable-Italic.ttf.woff2') format('woff2'),
-         url('./WOFF/VAR/SourceCodeVariable-Italic.ttf.woff') format('woff'),
-         url('./VAR/SourceCodeVariable-Italic.ttf') format('truetype');
+    src: url('./WOFF2/VAR/SourceCodeVariable-Italic.ttf.woff2') format('woff2-variations'),
+         url('./WOFF/VAR/SourceCodeVariable-Italic.ttf.woff') format('woff-variations'),
+         url('./VAR/SourceCodeVariable-Italic.ttf') format('truetype-variations');
 }


### PR DESCRIPTION
This is required to let browsers that don’t support variable fonts (e.g. Firefox on Windows 8) avoid downloading them and fall back to something usable.