### PR TITLE
Fixed outdated directories/filenames in source-code-variable.css

### DIFF
--- a/source-code-variable.css
+++ b/source-code-variable.css
@@ -3,9 +3,9 @@
     font-weight: 200 900;
     font-style: normal;
     font-stretch: normal;
-    src: url('./WOFF2/VAR/SourceCodeVariable-Roman.ttf.woff2') format('woff2'),
-         url('./WOFF/VAR/SourceCodeVariable-Roman.ttf.woff') format('woff'),
-         url('./VAR/SourceCodeVariable-Roman.ttf') format('truetype');
+    src: url('./WOFF2/VF/SourceCodeVF-Upright.ttf.woff2') format('woff2'),
+         url('./WOFF/VF/SourceCodeVF-Upright.ttf.woff') format('woff'),
+         url('./VF/SourceCodeVF-Upright.ttf') format('truetype');
 }
 
 @font-face{
@@ -13,7 +13,7 @@
     font-weight: 200 900;
     font-style: italic;
     font-stretch: normal;
-    src: url('./WOFF2/VAR/SourceCodeVariable-Italic.ttf.woff2') format('woff2'),
-         url('./WOFF/VAR/SourceCodeVariable-Italic.ttf.woff') format('woff'),
-         url('./VAR/SourceCodeVariable-Italic.ttf') format('truetype');
+    src: url('./WOFF2/VF/SourceCodeVF-Italic.ttf.woff2') format('woff2'),
+         url('./WOFF/VF/SourceCodeVF-Italic.ttf.woff') format('woff'),
+         url('./VF/SourceCodeVF-Italic.ttf') format('truetype');
 }


### PR DESCRIPTION
Various directories/filenames in source-code-variable.css are outdated. This patch corrects these directories/filenames.